### PR TITLE
Removed 5% margin from navmenu mediaQ  at 500px: index page

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5502
+}

--- a/css/index.css
+++ b/css/index.css
@@ -158,7 +158,7 @@ body {
 }
 @media (max-width: 1030px) {
   body {
-    margin: 2% 5%;
+    margin: 2% 0;
   }
 }
 
@@ -175,7 +175,7 @@ nav {
 }
 .navigation a {
   font-size: 18px;
-  margin: 10px 0 0 0;
+  margin: 10px;
   text-decoration: none;
 }
 
@@ -319,6 +319,9 @@ address {
   }
 }
 @media (max-width: 500px) {
+  body {
+    margin: 0;
+  }
   .navigation {
     flex-direction: column;
   }


### PR DESCRIPTION
@hyetigran 
Fixes # 
![tempsnip](https://user-images.githubusercontent.com/44614620/66428480-61a69d00-ea16-11e9-9911-5b15ab70166c.jpg)
